### PR TITLE
Switch UTF-8 conversion to go to UTF-16 instead of unsigned long long

### DIFF
--- a/ext/jaro_winkler/adj_matrix.c
+++ b/ext/jaro_winkler/adj_matrix.c
@@ -16,38 +16,32 @@ AdjMatrix* adj_matrix_new(unsigned int length){
   AdjMatrix *matrix = malloc(sizeof(AdjMatrix));
   matrix->length = length == 0 ? ADJ_MATRIX_DEFAULT_LENGTH : length;
   matrix->table = malloc(matrix->length * sizeof(Node**));
-  for(int i = 0; i < matrix->length; i++){
+  for(unsigned int i = 0; i < matrix->length; i++){
     matrix->table[i] = malloc(matrix->length * sizeof(Node*));
-    for (int j = 0; j < matrix->length; j++)
+    for (unsigned int j = 0; j < matrix->length; j++)
       matrix->table[i][j] = NULL;
   }
   return matrix;
 }
 
-void adj_matrix_add(AdjMatrix *matrix, unsigned long long x, unsigned long long y){
-  unsigned int h1 = MurmurHash2(&x, sizeof(long long), ADJ_MATRIX_SEED) % ADJ_MATRIX_DEFAULT_LENGTH,
-               h2 = MurmurHash2(&y, sizeof(long long), ADJ_MATRIX_SEED) % ADJ_MATRIX_DEFAULT_LENGTH;
-  Node *new_node = malloc(sizeof(Node)); new_node->x = h1; new_node->y = h2; new_node->next = NULL;
-  if(matrix->table[h1][h2] == NULL){
-    matrix->table[h1][h2] = matrix->table[h2][h1] = new_node;
-  }
-  else{
-    Node *previous = NULL;
-    for(Node *i = matrix->table[h1][h2]; i != NULL; i = i->next) previous = i;
-    previous->next = new_node;
-  }
+void adj_matrix_add(AdjMatrix *matrix, UnicodeCharCode x, UnicodeCharCode y){
+  unsigned int h1 = MurmurHash2(&x, sizeof(UnicodeCharCode), ADJ_MATRIX_SEED) % matrix->length,
+               h2 = MurmurHash2(&y, sizeof(UnicodeCharCode), ADJ_MATRIX_SEED) % matrix->length;
+  Node *new_node = malloc(sizeof(Node)); new_node->x = h1; new_node->y = h2; 
+  new_node->next = matrix->table[h1][h2];
+  matrix->table[h1][h2] = matrix->table[h2][h1] = new_node;
 }
 
-char adj_matrix_find(AdjMatrix *matrix, unsigned long long x, unsigned long long y){
-  unsigned int h1 = MurmurHash2(&x, sizeof(long long), ADJ_MATRIX_SEED) % ADJ_MATRIX_DEFAULT_LENGTH,
-               h2 = MurmurHash2(&y, sizeof(long long), ADJ_MATRIX_SEED) % ADJ_MATRIX_DEFAULT_LENGTH;
-  Node *node = matrix->table[h1][h2];
-  if(node == NULL) return 0;
-  else{
-    for(Node *i = node; i != NULL; i = i->next)
-      if((i->x == h1 && i->y == h2) || (i->x == h2 && i->y == h1)) return 1;
-    return 0;
+char adj_matrix_find(AdjMatrix *matrix, UnicodeCharCode x, UnicodeCharCode y){
+  unsigned int h1 = MurmurHash2(&x, sizeof(UnicodeCharCode), ADJ_MATRIX_SEED) % matrix->length,
+               h2 = MurmurHash2(&y, sizeof(UnicodeCharCode), ADJ_MATRIX_SEED) % matrix->length;
+  const Node *node = matrix->table[h1][h2];
+  while (node) {
+    if ((node->x == h1 && node->y == h2) || (node->x == h2 && node->y == h1))
+      return 1;
+    node = node->next;
   }
+  return 0;
 }
 
 void node_free(Node *head){
@@ -57,8 +51,8 @@ void node_free(Node *head){
 }
 
 void adj_matrix_free(AdjMatrix *matrix){
-  for(int i = 0; i < matrix->length; i++){
-    for(int j = 0; j < matrix->length; j++)
+  for(unsigned int i = 0; i < matrix->length; i++){
+    for(unsigned int j = 0; j < matrix->length; j++)
       if(matrix->table[i][j] != NULL){
         node_free(matrix->table[i][j]);
         matrix->table[i][j] = matrix->table[j][i] = NULL;

--- a/ext/jaro_winkler/adj_matrix.h
+++ b/ext/jaro_winkler/adj_matrix.h
@@ -1,11 +1,12 @@
 #ifndef ADJ_MATRIX_H
 #define ADJ_MATRIX_H 1
+#include "codepoints.h"
 #define ADJ_MATRIX_DEFAULT_LENGTH 958
 #define ADJ_MATRIX_SEED 9527
 
 typedef struct _node{
   struct _node *next;
-  unsigned long long x, y;
+  UnicodeCharCode x, y;
 } Node;
 
 typedef struct{
@@ -14,8 +15,8 @@ typedef struct{
 } AdjMatrix;
 
 AdjMatrix* adj_matrix_new    (unsigned int length);
-void       adj_matrix_add    (AdjMatrix *matrix, unsigned long long x, unsigned long long y);
-char       adj_matrix_find   (AdjMatrix *matrix, unsigned long long x, unsigned long long y);
+void       adj_matrix_add    (AdjMatrix *matrix, UnicodeCharCode x, UnicodeCharCode y);
+char       adj_matrix_find   (AdjMatrix *matrix, UnicodeCharCode x, UnicodeCharCode y);
 void       adj_matrix_free   (AdjMatrix *matrix);
 AdjMatrix* adj_matrix_default();
 

--- a/ext/jaro_winkler/codepoints.c
+++ b/ext/jaro_winkler/codepoints.c
@@ -2,27 +2,51 @@
 #include <stdlib.h>
 #include "codepoints.h"
 
+/**
+ * Convert a single UTF-8 character (possiblity in multiple bytes
+ * to a single UTF-16 character. This implementation is based
+ * on the following article: http://en.wikipedia.org/wiki/UTF-8.
+ * According to RFC 3629 UTF-8 maps into U+0000..U+10FFFF,
+ * the UTF-16 compatible characters, and it can only have up
+ * to 4 UTF-8 bytes per UTF-16 character.
+ */
 UnicodeHash unicode_hash_new(const char *str){
-  UnicodeHash ret = {};
-  unsigned char first_char = str[0];
-  if(first_char >= 252) ret.byte_length = 6;      // 1111110x
-  else if(first_char >= 248) ret.byte_length = 5; // 111110xx
-  else if(first_char >= 240) ret.byte_length = 4; // 11110xxx
-  else if(first_char >= 224) ret.byte_length = 3; // 1110xxxx
-  else if(first_char >= 192) ret.byte_length = 2; // 110xxxxx
-  else ret.byte_length = 1;
-  memcpy(&ret.code, str, ret.byte_length);
+  UnicodeHash ret = { 0u, 0u };
+  const unsigned char first_char = (unsigned char)str[0];
+  if ((first_char & 0x80) && (first_char & 0x40)) {
+    if (first_char & 0x20) {
+      if (first_char & 0x10) { // four bytes
+	ret.code = ((str[1] & 0x3f) << 12) | ((str[2] & 0x3f) << 6) | (str[3] & 0x3f);
+	ret.byte_length = 4;
+      }
+      else {
+	ret.code = ((first_char & 0x0f) << 12) | ((str[1] & 0x3f) << 6) | (str[2] & 0x3f);
+	ret.byte_length = 3;
+      }
+    }
+    else {
+      ret.code = ((first_char & 0x1f) << 6) | (str[1] & 0x3f);
+      ret.byte_length = 2;
+    }
+  }
+  else {
+    ret.code = first_char & 0X7f;
+    ret.byte_length = 1;
+  }
   return ret;
 }
 
+/**
+ * Convert a string in UTF-8 to an equivalent string in UTF-16.
+ */
 Codepoints codepoints_new(const char *str, int byte_len){
   Codepoints ret = {};
-  ret.ary = malloc(byte_len * sizeof(long long));
+  ret.ary = malloc(byte_len * sizeof(UnicodeCharCode)); /* conservative */
   ret.length = 0;
   for(int i = 0; i < byte_len;){
     UnicodeHash hash = unicode_hash_new(str + i);
     ret.ary[ret.length] = hash.code;
-    ret.length++;
+    ++ret.length;
     i += hash.byte_length;
   }
   return ret;

--- a/ext/jaro_winkler/codepoints.h
+++ b/ext/jaro_winkler/codepoints.h
@@ -1,17 +1,30 @@
 #ifndef CODEPOINTS_H
 #define CODEPOINTS_H 1
 
+#include <stdint.h>
+
+typedef uint16_t UnicodeCharCode;
+
 typedef struct{
-  unsigned long long code;
-  unsigned int byte_length;
+  UnicodeCharCode code;		/* UTF-16 representation of a unicode character */
+  unsigned int byte_length;	/* how many bytes of UTF-8 encoding it came from */
 } UnicodeHash;
 
 typedef struct{
-  unsigned long long *ary;
+  UnicodeCharCode *ary;
   int length;
 } Codepoints;
 
+/**
+ * Convert a single UTF-8 character into its UTF-16
+ * equivalent. The UTF-8 representation of one
+ * UTF-16 character can take 1-4 bytes.
+ */
 UnicodeHash unicode_hash_new(const char *str);
+
+/**
+ * Convert str in UTF-8 encoding to a string in UTF-16 encoding.
+ */ 
 Codepoints  codepoints_new  (const char *str, int byte_len);
 
 #endif /* CODEPOINTS_H */

--- a/ext/jaro_winkler/distance.c
+++ b/ext/jaro_winkler/distance.c
@@ -17,14 +17,16 @@ double distance(char *s1, int s1_byte_len, char *s2, int s2_byte_len, Option opt
              code_ary_2 = codepoints_new(s2, s2_byte_len);
 
   if(opt.ignore_case){
-    for(int i = 0; i < code_ary_1.length; ++i) if(code_ary_1.ary[i] < 256 && islower(code_ary_1.ary[i])) code_ary_1.ary[i] -= 32;
-    for(int i = 0; i < code_ary_2.length; ++i) if(code_ary_2.ary[i] < 256 && islower(code_ary_2.ary[i])) code_ary_2.ary[i] -= 32;
+    for(int i = 0; i < code_ary_1.length; ++i) if(code_ary_1.ary[i] < 256u && islower(code_ary_1.ary[i])) code_ary_1.ary[i] -= 32u;
+    for(int i = 0; i < code_ary_2.length; ++i) if(code_ary_2.ary[i] < 256u && islower(code_ary_2.ary[i])) code_ary_2.ary[i] -= 32u;
   }
 
   // Guarantee the order
   if(code_ary_1.length > code_ary_2.length){
-    unsigned long long *tmp = code_ary_1.ary; code_ary_1.ary = code_ary_2.ary; code_ary_2.ary = tmp;
-    int tmp2 = code_ary_1.length; code_ary_1.length = code_ary_2.length; code_ary_2.length = tmp2;
+    UnicodeCharCode *tmp = code_ary_1.ary; 
+    int tmp2 = code_ary_1.length; 
+    code_ary_1.ary = code_ary_2.ary; code_ary_2.ary = tmp;
+    code_ary_1.length = code_ary_2.length; code_ary_2.length = tmp2;
   }
 
   // Compute jaro distance


### PR DESCRIPTION
I tried converting UTF-8 into uint16_t instead of unsigned long long. The wikipedia documentation on UTF-8 says that this should be valid. On my machine this makes the comparison faster.

```
Rehearsal ----------------------------------------------------
jaro_winkler       0.390000   0.000000   0.390000 (  0.381969)
fuzzystringmatch   0.510000   0.000000   0.510000 (  0.506941)
hotwater           0.580000   0.010000   0.590000 (  0.586986)
amatch             1.180000   0.000000   1.180000 (  1.177425)
------------------------------------------- total: 2.670000sec

                       user     system      total        real
jaro_winkler       0.380000   0.000000   0.380000 (  0.381681)
fuzzystringmatch   0.620000   0.000000   0.620000 (  0.625234)
hotwater           0.570000   0.000000   0.570000 (  0.569079)
amatch             1.030000   0.000000   1.030000 (  1.037745)
```

The benchmarks prior to the change are

```
Rehearsal ----------------------------------------------------
jaro_winkler       0.460000   0.000000   0.460000 (  0.460248)
fuzzystringmatch   0.500000   0.010000   0.510000 (  0.508658)
hotwater           0.580000   0.000000   0.580000 (  0.584665)
amatch             1.040000   0.000000   1.040000 (  1.055028)
------------------------------------------- total: 2.590000sec

                       user     system      total        real
jaro_winkler       0.470000   0.000000   0.470000 (  0.473629)
fuzzystringmatch   0.480000   0.000000   0.480000 (  0.488322)
hotwater           0.570000   0.000000   0.570000 (  0.573510)
amatch             1.150000   0.000000   1.150000 (  1.175987)
```

I expected it to be faster because it reduces the memory bandwidth requirements.
