### PR TITLE
WIP: Enforce pure ruby version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ bundler_args: --without benchmark
 os:
   - linux
   - osx
+env:
+  - JARO_WINKLER_PURE_RUBY=
+  - JARO_WINKLER_PURE_RUBY=yes
 rvm:
   - 2.5.0
   - 2.4.3

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ weight      | number  | 0.1     | A constant scaling factor for how much the sco
 threshold   | number  | 0.7     | The prefix bonus is only added when the compared strings have a Jaro distance above the threshold.
 adj_table   | boolean | false   | The option is used to give partial credit for characters that may be errors due to known phonetic or character recognition errors. A typical example is to match the letter "O" with the number "0".
 
+## Selecting Pure Ruby flavor
+
+```
+export JARO_WINKLER_PURE_RUBY=true
+gem install jaro_winkler
+```
+
 # Adjusting Table
 
 ## Default Table

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ task compare: :compile do
   table.each{|row| puts row.join(' | ')}
 end
 
-if RUBY_ENGINE == 'ruby'
+if RUBY_ENGINE == 'ruby' && ENV[JARO_WINKLER_PURE_RUBY].nil?
   Rake::ExtensionTask.new 'jaro_winkler_ext' do |ext|
     ext.lib_dir = 'lib/jaro_winkler'
     ext.ext_dir = 'ext/jaro_winkler'

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ task compare: :compile do
   table.each{|row| puts row.join(' | ')}
 end
 
-if RUBY_ENGINE == 'ruby' && ENV[JARO_WINKLER_PURE_RUBY].nil?
+if RUBY_ENGINE == 'ruby' && ENV['JARO_WINKLER_PURE_RUBY'].nil?
   Rake::ExtensionTask.new 'jaro_winkler_ext' do |ext|
     ext.lib_dir = 'lib/jaro_winkler'
     ext.ext_dir = 'ext/jaro_winkler'

--- a/lib/jaro_winkler.rb
+++ b/lib/jaro_winkler.rb
@@ -2,7 +2,7 @@
 
 require 'jaro_winkler/version'
 
-if RUBY_ENGINE == 'ruby'
+if RUBY_ENGINE == 'ruby' && ENV['JARO_WINKLER_PURE_RUBY'].nil?
   require 'jaro_winkler/jaro_winkler_ext'
 else
   require 'jaro_winkler/jaro_winkler_pure'

--- a/lib/jaro_winkler.rb
+++ b/lib/jaro_winkler.rb
@@ -2,7 +2,7 @@
 
 require 'jaro_winkler/version'
 
-if RUBY_ENGINE == 'ruby' && ENV['JARO_WINKLER_PURE_RUBY'].nil?
+if RUBY_ENGINE == 'ruby' && File.exists? 'jaro_winkler/jaro_winkler_ext'
   require 'jaro_winkler/jaro_winkler_ext'
 else
   require 'jaro_winkler/jaro_winkler_pure'


### PR DESCRIPTION
I was looking for a way to select the pure ruby version, as there may be circumstances where we can't afford to compile the native extension (missing libraries and headers) and don't need the performance of a native extension.