### PR TITLE
Rename Rake tasks for test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,8 @@ require 'rubygems/package_task'
 require 'rake/extensiontask'
 require 'rake/testtask'
 
-task default: %w[test:pure_ruby test:compiled]
+task default: :test
+task test: %w[test:pure_ruby test:compiled]
 
 task benchmark: %w[benchmark:native benchmark:pure]
 

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rubygems/package_task'
 require 'rake/extensiontask'
 require 'rake/testtask'
 
-task default: [:compile, :test]
+task default: %w[test:pure_ruby test:compiled]
 
 task benchmark: %w[benchmark:native benchmark:pure]
 
@@ -70,16 +70,18 @@ else
   end
 end
 
-Rake::TestTask.new do |t|
-  t.libs << 'test'
-  t.test_files = FileList['test/test_jaro_winkler.rb']
-  t.verbose = true
-end
+namespace :test do
+  Rake::TestTask.new(:compiled => :compile) do |t|
+    t.libs << 'test'
+    t.test_files = FileList['test/test_jaro_winkler.rb']
+    t.verbose = true
+  end
 
-Rake::TestTask.new do |t|
-  t.libs << 'test'
-  t.test_files = FileList['test/test_pure_ruby.rb']
-  t.verbose = true
+  Rake::TestTask.new(:pure_ruby) do |t|
+    t.libs << 'test'
+    t.test_files = FileList['test/test_pure_ruby.rb']
+    t.verbose = true
+  end
 end
 
 %w[jaro_winkler jaro_winkler.java]


### PR DESCRIPTION
Calling `Rake::TestTask.new` twice without an argument will result in just *one* test task called `test`.

This commit renames `rake test` to `rake test:compiled`, and fixes the second Rake test task which is now named `rake test:pure_ruby`. Additionally it specifies that `test:compiled` depends on `:compile` (I noticed this when trying to run the tests locally), and `rake default` is changed to run these two test tasks.