### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/jaro_winkler.gemspec
+++ b/jaro_winkler.gemspec
@@ -18,6 +18,12 @@ Gem::Specification.new do |spec|
   UTF-8, EUC-JP, Big5, etc.'
   spec.homepage = 'https://github.com/tonytonyjan/jaro_winkler'
   spec.license = 'MIT'
+  spec.metadata = {
+    'bug_tracker_uri' => 'https://github.com/tonytonyjan/jaro_winkler/issues',
+    'changelog_uri' => "https://github.com/tonytonyjan/jaro_winkler/blob/v#{spec.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/jaro_winkler/#{spec.version}",
+    'source_code_uri' => "https://github.com/tonytonyjan/jaro_winkler/tree/v#{spec.version}",
+  }
   spec.files = Dir['lib/**/*.rb', 'ext/**/*.{h,c}', 'LICENSE.txt']
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 12.0'

--- a/jaro_winkler.java.gemspec
+++ b/jaro_winkler.java.gemspec
@@ -17,6 +17,12 @@ Gem::Specification.new do |spec|
   UTF-8, EUC-JP, Big5, etc.'
   spec.homepage = 'https://github.com/tonytonyjan/jaro_winkler'
   spec.license = 'MIT'
+  spec.metadata = {
+    'bug_tracker_uri' => 'https://github.com/tonytonyjan/jaro_winkler/issues',
+    'changelog_uri' => "https://github.com/tonytonyjan/jaro_winkler/blob/v#{spec.version}/CHANGELOG.md",
+    'documentation_uri' => "https://www.rubydoc.info/gems/jaro_winkler/#{spec.version}",
+    'source_code_uri' => "https://github.com/tonytonyjan/jaro_winkler/tree/v#{spec.version}",
+  }
   spec.files = Dir['lib/**/*.rb', 'LICENSE.txt']
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/jaro_winkler), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.