### PR TITLE
Allow compiling the gem with MSVC (which is not C99 compliant)

### DIFF
--- a/ext/jaro_winkler/jaro.c
+++ b/ext/jaro_winkler/jaro.c
@@ -8,9 +8,9 @@
 
 #define DEFAULT_WEIGHT 0.1
 #define DEFAULT_THRESHOLD 0.7
-#define SWAP(x, y)                                                             \
+#define SWAP(type, x, y)                                                       \
   do {                                                                         \
-    __typeof__(x) SWAP = x;                                                    \
+    type SWAP = x;                                                             \
     x = y;                                                                     \
     y = SWAP;                                                                  \
   } while (0)
@@ -27,8 +27,8 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
     return 0.0;
 
   if (len1 > len2) {
-    SWAP(codepoints1, codepoints2);
-    SWAP(len1, len2);
+    SWAP(uint32_t*, codepoints1, codepoints2);
+    SWAP(size_t, len1, len2);
   }
 
   if (opt->ignore_case) {
@@ -42,8 +42,8 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
   if (window_size < 0)
     window_size = 0;
 
-  char short_codes_flag[len1];
-  char long_codes_flag[len2];
+  char * short_codes_flag = malloc(len1*sizeof(char));
+  char * long_codes_flag = malloc(len2*sizeof(char));
   memset(short_codes_flag, 0, len1);
   memset(long_codes_flag, 0, len2);
 
@@ -64,8 +64,11 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
     }
   }
 
-  if (!match_count)
+  if (!match_count) {
+    free(short_codes_flag);
+    free(long_codes_flag);
     return 0.0;
+  }
 
   // count number of transpositions
   size_t transposition_count = 0, j = 0, k = 0;
@@ -99,6 +102,10 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
   double t = (double)(transposition_count / 2);
   if (opt->adj_table)
     m = similar_count / 10.0 + m;
+
+  free(short_codes_flag);
+  free(long_codes_flag);
+
   return (m / len1 + m / len2 + (m - t) / m) / 3;
 }
 

--- a/ext/jaro_winkler/jaro.c
+++ b/ext/jaro_winkler/jaro.c
@@ -6,6 +6,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if HAVE_ALLOCA_H
+# include <alloca.h>
+#elif defined __GNUC__
+# define alloca __builtin_alloca
+#elif defined _AIX
+# define alloca __alloca
+#elif defined _MSC_VER
+# include <malloc.h>
+# define alloca _alloca
+#else
+# include <stddef.h>
+# ifdef  __cplusplus
+extern "C"
+# endif
+void *alloca (size_t);
+#endif
+
 #define DEFAULT_WEIGHT 0.1
 #define DEFAULT_THRESHOLD 0.7
 #define SWAP(type, x, y)                                                       \

--- a/ext/jaro_winkler/jaro.c
+++ b/ext/jaro_winkler/jaro.c
@@ -42,8 +42,8 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
   if (window_size < 0)
     window_size = 0;
 
-  char * short_codes_flag = malloc(len1*sizeof(char));
-  char * long_codes_flag = malloc(len2*sizeof(char));
+  char * short_codes_flag = alloca(len1);
+  char * long_codes_flag = alloca(len2);
   memset(short_codes_flag, 0, len1);
   memset(long_codes_flag, 0, len2);
 
@@ -65,8 +65,6 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
   }
 
   if (!match_count) {
-    free(short_codes_flag);
-    free(long_codes_flag);
     return 0.0;
   }
 
@@ -102,9 +100,6 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
   double t = (double)(transposition_count / 2);
   if (opt->adj_table)
     m = similar_count / 10.0 + m;
-
-  free(short_codes_flag);
-  free(long_codes_flag);
 
   return (m / len1 + m / len2 + (m - t) / m) / 3;
 }

--- a/jaro_winkler.gemspec
+++ b/jaro_winkler.gemspec
@@ -25,8 +25,8 @@ Gem::Specification.new do |spec|
     'source_code_uri' => "https://github.com/tonytonyjan/jaro_winkler/tree/v#{spec.version}",
   }
   spec.files = Dir['lib/**/*.rb', 'ext/**/*.{h,c}', 'LICENSE.txt']
-  spec.add_development_dependency 'bundler', '~> 1.7'
-  spec.add_development_dependency 'rake', '~> 12.0'
+  spec.add_development_dependency 'bundler', '~> 2.1'
+  spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rake-compiler'
   spec.add_development_dependency 'minitest'
 end


### PR DESCRIPTION
I realize this is probably a corner case (using MSVC to compile a ruby gem), but that's he situation I am in: I have to use MSVC to compile this gem as we have a C++ application that has to be built on MSVC and one thing it does is to create a CLI based on ruby and embedded some gems.

The fun stuff is that MSVC (including the 2019 16.5.1 that I use which is fully up to date) isn't C99 compliant, it's C89 compliant. So in order to be able to build the C extension in this repo, I had to do the following changes:

* Do not use Variable-length arrays (VLA) but instead use a heap array with malloc & free
* Redefine a macro to pass the type


**Edit**: Well actually, what a coincidence, I see this PR actually fixes an open issue. Fix #41