### PR TITLE
Ensure that ractor is considered safe.

### DIFF
--- a/ext/jaro_winkler/jaro_winkler.c
+++ b/ext/jaro_winkler/jaro_winkler.c
@@ -12,6 +12,11 @@ VALUE distance(size_t argc, VALUE *argv, VALUE self,
                                      Options *));
 
 void Init_jaro_winkler_ext(void) {
+
+#ifdef HAVE_RB_EXT_RACTOR_SAFE
+    rb_ext_ractor_safe(true);
+#endif
+
   rb_mJaroWinkler = rb_define_module("JaroWinkler");
   rb_eError = rb_define_class_under(rb_mJaroWinkler, "Error", rb_eRuntimeError);
   rb_eInvalidWeightError =


### PR DESCRIPTION
Now this library is considered `ractor unsafe method` by ruby3 interpreter.
I've fixed it.


```
% ruby -rjaro_winkler -e 'r = Ractor.new { JaroWinkler.distance("a", "a") }; r.take'
<internal:ractor>:267: warning: Ractor is experimental, and the behavior may change in future versions of Ruby! Also there are many implementation issues.
#<Thread:0x00007f9835970ef8 run> terminated with exception (report_on_exception is true):
-e:1:in `distance': ractor unsafe method called from not main ractor (Ractor::UnsafeError)
        from -e:1:in `block in <main>'
<internal:ractor>:694:in `take': thrown by remote Ractor. (Ractor::RemoteError)
        from -e:1:in `<main>'
-e:1:in `distance': ractor unsafe method called from not main ractor (Ractor::UnsafeError)
        from -e:1:in `block in <main>'
```