### PR TITLE
Update argc type from size_t to int

### DIFF
--- a/ext/jaro_winkler/jaro_winkler.c
+++ b/ext/jaro_winkler/jaro_winkler.c
@@ -4,9 +4,9 @@
 
 VALUE rb_mJaroWinkler, rb_eError, rb_eInvalidWeightError;
 
-VALUE rb_jaro_winkler_distance(size_t argc, VALUE *argv, VALUE self);
-VALUE rb_jaro_distance(size_t argc, VALUE *argv, VALUE self);
-VALUE distance(size_t argc, VALUE *argv, VALUE self,
+VALUE rb_jaro_winkler_distance(int argc, VALUE *argv, VALUE self);
+VALUE rb_jaro_distance(int argc, VALUE *argv, VALUE self);
+VALUE distance(int argc, VALUE *argv, VALUE self,
                double (*distance_fn)(uint32_t *codepoints1, size_t len1,
                                      uint32_t *codepoints2, size_t len2,
                                      Options *));
@@ -22,13 +22,13 @@ void Init_jaro_winkler_ext(void) {
                              -1);
 }
 
-VALUE distance(size_t argc, VALUE *argv, VALUE self,
+VALUE distance(int argc, VALUE *argv, VALUE self,
                double (*distance_fn)(uint32_t *codepoints1, size_t len1,
                                      uint32_t *codepoints2, size_t len2,
                                      Options *)) {
   VALUE s1, s2, opt;
 
-  rb_scan_args((int32_t)argc, argv, "2:", &s1, &s2, &opt);
+  rb_scan_args(argc, argv, "2:", &s1, &s2, &opt);
 
   Check_Type(s1, T_STRING);
   Check_Type(s2, T_STRING);
@@ -63,10 +63,10 @@ VALUE distance(size_t argc, VALUE *argv, VALUE self,
   return ret;
 }
 
-VALUE rb_jaro_distance(size_t argc, VALUE *argv, VALUE self) {
+VALUE rb_jaro_distance(int argc, VALUE *argv, VALUE self) {
   return distance(argc, argv, self, jaro_distance_from_codes);
 }
 
-VALUE rb_jaro_winkler_distance(size_t argc, VALUE *argv, VALUE self) {
+VALUE rb_jaro_winkler_distance(int argc, VALUE *argv, VALUE self) {
   return distance(argc, argv, self, jaro_winkler_distance_from_codes);
 }


### PR DESCRIPTION
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`4c6ed4f`](https://github.com/tonytonyjan/jaro_winkler/pull/52/commits/4c6ed4f2c3e7772ee7d935fbb85c7bee5b689283) fix: Update argc type from size_t to int

There was some rework in Ruby around ANYARGS and it now doesn't compile
with Ruby 2.7.8 and 3.2.2 on macOS due to signature mismatch.

Under Linux this is only a warning:

    /usr/local/include/ruby-3.2.0/ruby/internal/anyargs.h:308:143: warning: passing argument 3 of ‘rb_define_singleton_method_m1’ from incompatible pointer type [-Wincompatible-pointer-types]
      308 | #define rb_define_singleton_method(obj, mid, func, arity)   RBIMPL_ANYARGS_DISPATCH_rb_define_singleton_method((arity), (func))((obj), (mid), (func), (arity))
          |                                                                                                                                               ^~~~~~
          |                                                                                                                                               |
          |                                                                                                                                               VALUE (*)(size_t,  VALUE *, VALUE) {aka long unsigned int (*)(long unsigned int,  long unsigned int *, long unsigned int)}


<!-- === GH HISTORY FENCE === -->
