### PR TITLE
chore: use "similarity" methods over deprecated "distance" methods for rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,7 @@ task compare: :compile do
   table << %w[--- --- --- --- --- ---]
   jarow = FuzzyStringMatch::JaroWinkler.create(:native)
   @ary.each do |str_1, str_2|
-    table << ["\"#{str_1}\"", "\"#{str_2}\"", JaroWinkler.distance(str_1, str_2).round(4), jarow.getDistance(str_1, str_2).round(4), Hotwater.jaro_winkler_distance(str_1, str_2).round(4), Amatch::Jaro.new(str_1).match(str_2).round(4)]
+    table << ["\"#{str_1}\"", "\"#{str_2}\"", JaroWinkler.similarity(str_1, str_2).round(4), jarow.getDistance(str_1, str_2).round(4), Hotwater.jaro_winkler_distance(str_1, str_2).round(4), Amatch::Jaro.new(str_1).match(str_2).round(4)]
   end
   col_len = []
   table.first.length.times{ |i| col_len << table.map{ |row| row[i].to_s.length }.max }

--- a/benchmark/measure.rb
+++ b/benchmark/measure.rb
@@ -28,8 +28,8 @@ if version >= Gem::Version.new('1.2.0')
 end
 
 if version >= Gem::Version.new('1.4.0')
-  jobs[:ascii] = -> { n.times { SAMPLES[:ascii].each { |str1, str2| JaroWinkler.distance(str1, str2) } } }
-  jobs[:utf8] = -> { n.times { SAMPLES[:utf8].each { |str1, str2| JaroWinkler.distance(str1, str2) } } }
+  jobs[:ascii] = -> { n.times { SAMPLES[:ascii].each { |str1, str2| JaroWinkler.similarity(str1, str2) } } }
+  jobs[:utf8] = -> { n.times { SAMPLES[:utf8].each { |str1, str2| JaroWinkler.similarity(str1, str2) } } }
 end
 
 # rehearsal

--- a/benchmark/native.rb
+++ b/benchmark/native.rb
@@ -11,7 +11,7 @@ n = 100_000
 
 Benchmark.bmbm do |x|
   x.report "jaro_winkler (#{`git rev-parse --short HEAD`.chop!})" do
-    n.times { SAMPLES[:ascii].each { |str1, str2| JaroWinkler.distance(str1, str2) } }
+    n.times { SAMPLES[:ascii].each { |str1, str2| JaroWinkler.similarity(str1, str2) } }
   end
 
   x.report gem_name_with_version('fuzzy-string-match') do

--- a/benchmark/pure.rb
+++ b/benchmark/pure.rb
@@ -9,7 +9,7 @@ n = 10_000
 
 Benchmark.bmbm do |x|
   x.report "jaro_winkler (#{`git rev-parse --short HEAD`.chop!})" do
-    n.times { SAMPLES[:ascii].each { |str1, str2| JaroWinkler.distance(str1, str2) } }
+    n.times { SAMPLES[:ascii].each { |str1, str2| JaroWinkler.similarity(str1, str2) } }
   end
 
   x.report gem_name_with_version('fuzzy-string-match') do


### PR DESCRIPTION
This change removes a lot of deprecation warnings from `rake compare` and `rake benchmark` executions.

It follows up to the commit d662816ee2b16aa9b513ad05099bd438e53cdbb2 (PR #55).

---

@tonytonyjan Today, thank you a lot for providing the contribution opportunity in person. I opened this PR because I just noticed my PR (#55) still needed more changes to dismiss the new deprecation warning. But if this is out of your mind, please don't hesitate to close it. 😊 👍🏼 