### PR TITLE
use append cflags instead of cflags environment variable

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,14 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - ubuntu-22.04
+          - ubuntu-24.04
           - macos-latest
-          - macos-13
+          - macos-15
           - windows-latest
-          - windows-2022
+          - windows-2025
         ruby:
           - "2.7"
-          - "3.0"
-          - "3.1"
-          - "3.2"
+          - "3.4"
           - head
         include:
           - fallible: false

--- a/ext/jaro_winkler/extconf.rb
+++ b/ext/jaro_winkler/extconf.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 require 'mkmf'
-$CFLAGS << ' -std=c99 '
+append_cflags(['-std=c99'])
 create_makefile('jaro_winkler/jaro_winkler_ext')


### PR DESCRIPTION
Use `append_cflags` instead of `CFLAGS` environment variable. `append_cflags` recommended over `CFLAGS` because it ensures compatibility across different build environments by checking whether the flag is acceptable.

ref:

https://github.com/RubyCrypto/ed25519/issues/44
https://bugs.ruby-lang.org/issues/21290
#61

In addition, updated CI strategy matrix.