### PR TITLE
Rebase #43: allow compiling the gem with MSVC (which is not C99 compliant)

### DIFF
--- a/ext/jaro_winkler/jaro.c
+++ b/ext/jaro_winkler/jaro.c
@@ -6,11 +6,28 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if HAVE_ALLOCA_H
+# include <alloca.h>
+#elif defined __GNUC__
+# define alloca __builtin_alloca
+#elif defined _AIX
+# define alloca __alloca
+#elif defined _MSC_VER
+# include <malloc.h>
+# define alloca _alloca
+#else
+# include <stddef.h>
+# ifdef  __cplusplus
+extern "C"
+# endif
+void *alloca (size_t);
+#endif
+
 #define DEFAULT_WEIGHT 0.1
 #define DEFAULT_THRESHOLD 0.7
-#define SWAP(x, y)                                                             \
+#define SWAP(type, x, y)                                                       \
   do {                                                                         \
-    __typeof__(x) SWAP = x;                                                    \
+    type SWAP = x;                                                             \
     x = y;                                                                     \
     y = SWAP;                                                                  \
   } while (0)
@@ -27,8 +44,8 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
     return 0.0;
 
   if (len1 > len2) {
-    SWAP(codepoints1, codepoints2);
-    SWAP(len1, len2);
+    SWAP(uint32_t*, codepoints1, codepoints2);
+    SWAP(size_t, len1, len2);
   }
 
   if (opt->ignore_case) {
@@ -42,8 +59,8 @@ double jaro_distance_from_codes(uint32_t *codepoints1, size_t len1,
   if (window_size < 0)
     window_size = 0;
 
-  char short_codes_flag[len1];
-  char long_codes_flag[len2];
+  char * short_codes_flag = alloca(len1);
+  char * long_codes_flag = alloca(len2);
   memset(short_codes_flag, 0, len1);
   memset(long_codes_flag, 0, len2);
 


### PR DESCRIPTION
Hi @tonytonyjan,

I've rebased the work from #43 and was able to compile it on Windows with MSVC without any issues.

The jaro_winkler gem is used in important projects like [Solargraph](https://github.com/castwide/solargraph).
With these changes, I was able to run Solargraph on a Ruby built with MSVC (ruby x64-mswin64_140). Unfortunately, I’m restricted to this environment, so native MSVC support is important.

Could you review and, if everything looks good, merge this and bump a release?

## Testing

Ruby + Windows + MSVC are not the best combo...

You could use [`conda`](https://github.com/conda-forge/miniforge) or [`pixi`](https://pixi.prefix.dev/latest/) package managers for testing. Both pull `ruby x64-mswin64_10` from [conda-forge](https://github.com/conda-forge) repositories.

In my tests I was using ruby 3.2.2.

You'll also need to install the correct Visual Studio Build Tools version from Microsoft. It can't be installed using a package manager due to licensing reasons.

For ruby 3.2.2 is Visual Studio Build Tools 2019: https://aka.ms/vs/16/release/vs_buildtools.exe

If using `conda` or `pixi` you'll also need to make the build tools available to your environment. Check https://github.com/conda-forge/vc-feedstock for more information on needed packages. For Visual Studio Build Tools 2019 is `vs2019_win-64`.

### Example

```sh
pixi init
pixi add ruby=3.2.2
pixi add vs2019_win-64
pixi shell
# ... build and install normally
```

